### PR TITLE
Resolve URI refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Server and client built with Python sockets
 
 **Author**: Megan Flood, Marco Zangari
 
-**Version**: 4.1.0
+**Version**: 4.1.1
 
 ## Overview
 To make a simple blocking http server and client to receive http requests and send http responses. Also to make a simple concurrent http server using gevent.
@@ -30,6 +30,8 @@ python client.py <add your request>
 Written in Python, built using gevent, tested with pytest and tox.
 
 ## Change Log
+**10-29-2017 9:50pm** - Refactored resolution of URI to improve security
+
 **10-29-2017 7:46pm** - Concurrent server module added, built using gevent
 
 **10-29-2017 6:00pm** - Server responds with files requested through HTTP GET requests

--- a/src/server.py
+++ b/src/server.py
@@ -155,7 +155,8 @@ def resolve_uri(uri):
     if not abs_uri.startswith(root_path):
         raise OSError('Access Denied')
 
-    try:
+    if os.path.isfile(abs_uri):
+
         with open(abs_uri, 'rb') as file:
             body = file.read()
 
@@ -163,22 +164,21 @@ def resolve_uri(uri):
 
         return body, file_type or 'text/plain'
 
-    except IOError as error:
-        if 'Is a directory' in error.args:
+    elif os.path.isdir(abs_uri):
 
-            body = """<!DOCTYPE html>
+        body = """<!DOCTYPE html>
 <html>
 <body>
 """
-            for item in os.listdir(abs_uri):
-                body += item + '\n'
-            body += """</body>
+        for item in os.listdir(abs_uri):
+            body += item + '\n'
+        body += """</body>
 </html>
 """
-            return body.encode('utf8'), 'text/html'
+        return body.encode('utf8'), 'text/html'
 
-        else:
-            raise error
+    else:
+        raise IOError('No such file or directory.')
 
 if __name__ == "__main__":  # pragma: no cover
     server()

--- a/src/server.py
+++ b/src/server.py
@@ -146,52 +146,38 @@ def resolve_uri(uri):
     OSError - Access denied. URI is not inside the root directory.
     IOError - No such file or directory.
     """
-    script_root_path = os.path.abspath(__file__).rsplit('/', 2)[0]
+    script_root_path = os.path.abspath(__file__).rsplit('/', 1)[0]
 
-    root_path = script_root_path + '/src/webroot'
+    root_path = script_root_path + '/webroot'
 
-    os.chdir(root_path)
+    abs_uri = os.path.abspath(root_path + uri)
 
-    uri = '.' + uri
-
-    abs_uri = os.path.abspath(uri)
     if not abs_uri.startswith(root_path):
         raise OSError('Access Denied')
 
     try:
-        os.chdir(uri)
+        with open(abs_uri, 'rb') as file:
+            body = file.read()
 
-        body = """<!DOCTYPE html>
+        file_type = guess_type(abs_uri)[0]
+
+        return body, file_type or 'text/plain'
+
+    except IOError as error:
+        if 'Is a directory' in error.args:
+
+            body = """<!DOCTYPE html>
 <html>
 <body>
 """
-        for item in os.listdir('.'):
-            body += item + '\n'
-        body += """</body>
+            for item in os.listdir(abs_uri):
+                body += item + '\n'
+            body += """</body>
 </html>
 """
-        os.chdir(script_root_path)
-        return body.encode('utf8'), 'text/html'
-
-    except OSError as error:
-        if 'No such file or directory' in error.args:
-            os.chdir(script_root_path)
-            raise IOError('No such file or directory: ' + error.filename)
-
-        elif 'Not a directory' in error.args:
-            dir_path, file_name = uri.rsplit('/', 1)
-            os.chdir(dir_path)
-
-            with open(file_name, 'rb') as file:
-                body = file.read()
-
-            file_type = guess_type(file_name)[0]
-
-            os.chdir(script_root_path)
-            return body, file_type or 'text/plain'
+            return body.encode('utf8'), 'text/html'
 
         else:
-            os.chdir(script_root_path)
             raise error
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Refactored the resolve-uri function so that the directory is never changed. Only uses absolute paths based on the webroot to open files and list the contents of directories. Also, now attempts to resolve the URI as a file first, thus reducing the complexity of the except statement.